### PR TITLE
Move the Go version used in workflows to a central location to make it easier to update

### DIFF
--- a/.github/workflows/constants.env
+++ b/.github/workflows/constants.env
@@ -1,0 +1,3 @@
+# Constants shared accross workflows
+
+GO_VERSION="1.20"

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -7,15 +7,17 @@ on:
 
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   lint-workflows:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -10,15 +10,17 @@ on:
 
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   check-mod-tidy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -43,6 +45,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
@@ -62,6 +69,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ on:
     tags:
       - "v*.*.*"
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   release-binary:
     runs-on: ubuntu-latest
@@ -22,6 +19,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Checkout tags
         run: git fetch --force --tags

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,17 @@ on:
 
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   race-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -43,6 +45,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
@@ -64,6 +71,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -10,15 +10,17 @@ on:
 
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
While here, also update to Go 1.20.